### PR TITLE
Add support for path beginning with parent directory (..)

### DIFF
--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -181,7 +181,12 @@ bool has_magic(const std::string &pathname) {
 }
 
 static inline 
-bool is_hidden(const std::string &pathname) { return pathname[0] == '.'; }
+bool is_hidden(const std::string &pathname) {
+  // path is hidden if it starts with dot and is not parent dir nor current dir
+  if (pathname.size() >= 2)
+    return pathname.at(0) == '.' && pathname.at(1) != '.' && pathname.at(1) != '/';
+  return pathname[0] == '.';
+}
 
 static inline 
 bool is_recursive(const std::string &pattern) { return pattern == "**"; }

--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -182,10 +182,7 @@ bool has_magic(const std::string &pathname) {
 
 static inline 
 bool is_hidden(const std::string &pathname) {
-  // path is hidden if it starts with dot and is not parent dir nor current dir
-  if (pathname.size() >= 2)
-    return pathname.at(0) == '.' && pathname.at(1) != '.' && pathname.at(1) != '/';
-  return pathname[0] == '.';
+  return std::regex_match(pathname, std::regex("^(.*\\/)*\\.[^\\.\\/]+\\/*$"));
 }
 
 static inline 


### PR DESCRIPTION
This PR adds support for paths starting with the parent directory (..). It modifies the is_hidden() function so that paths starting with parent directory ( ../ ) or current directory ( ./ ) should not be considered hidden.