### PR TITLE
glob.hpp: fix typo (ressult -> result)

### DIFF
--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -89,7 +89,7 @@ std::string translate(const std::string &pattern) {
 
         // Escape set operations (&&, ~~ and ||).
         std::string result;
-        std::regex_replace(std::back_inserter(result),          // ressult
+        std::regex_replace(std::back_inserter(result),          // result
                            stuff.begin(), stuff.end(),          // string
                            std::regex(std::string{R"([&~|])"}), // pattern
                            std::string{R"(\\\1)"});             // repl


### PR DESCRIPTION
Unfortunately, github's online interface always adds a trailing newline, and it appears impossible to remove