### PR TITLE
Add CMake option to compile with `gulrak/filesystem`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ project(
   LANGUAGES CXX
 )
 
+# ---- Options ----
+option(GLOB_USE_GHC_FILESYSTEM "Use ghc::filesystem instead of std::filesystem" OFF)
+
 # ---- Include guards ----
 
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
@@ -46,6 +49,12 @@ file(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/
 add_library(Glob ${headers} ${sources})
 SET_TARGET_PROPERTIES(Glob PROPERTIES OUTPUT_NAME glob)
 set_target_properties(Glob PROPERTIES CXX_STANDARD 17)
+
+if ( GLOB_USE_GHC_FILESYSTEM )
+  # Switch to ghc::filesystem.
+  target_link_libraries(Glob PRIVATE ghcFilesystem::ghc_filesystem)
+  target_compile_definitions(Glob PUBLIC GLOB_USE_GHC_FILESYSTEM)
+endif()
 
 # being a cross-platform target, we enforce standards conformance on MSVC
 target_compile_options(Glob PUBLIC "$<$<BOOL:${MSVC}>:/permissive->")

--- a/include/glob/glob.h
+++ b/include/glob/glob.h
@@ -1,12 +1,21 @@
 
 #pragma once
-#include <filesystem>
 #include <string>
 #include <vector>
 
+#ifdef GLOB_USE_GHC_FILESYSTEM
+#include <ghc/filesystem.hpp>
+#else
+#include <filesystem>
+#endif
+
 namespace glob {
 
+#ifdef GLOB_USE_GHC_FILESYSTEM
+namespace fs = ghc::filesystem;
+#else
 namespace fs = std::filesystem;
+#endif
 
 /// \param pathname string containing a path specification
 /// \return vector of paths that match the pathname

--- a/include/glob/glob.h
+++ b/include/glob/glob.h
@@ -6,13 +6,15 @@
 
 namespace glob {
 
+namespace fs = std::filesystem;
+
 /// \param pathname string containing a path specification
 /// \return vector of paths that match the pathname
 ///
 /// Pathnames can be absolute (/usr/src/Foo/Makefile) or relative (../../Tools/*/*.gif)
 /// Pathnames can contain shell-style wildcards
 /// Broken symlinks are included in the results (as in the shell)
-std::vector<std::filesystem::path> glob(const std::string &pathname);
+std::vector<fs::path> glob(const std::string &pathname);
 
 /// \param pathnames string containing a path specification
 /// \return vector of paths that match the pathname
@@ -20,21 +22,21 @@ std::vector<std::filesystem::path> glob(const std::string &pathname);
 /// Globs recursively.
 /// The pattern “**” will match any files and zero or more directories, subdirectories and
 /// symbolic links to directories.
-std::vector<std::filesystem::path> rglob(const std::string &pathname);
+std::vector<fs::path> rglob(const std::string &pathname);
 
 /// Runs `glob` against each pathname in `pathnames` and accumulates the results
-std::vector<std::filesystem::path> glob(const std::vector<std::string> &pathnames);
+std::vector<fs::path> glob(const std::vector<std::string> &pathnames);
 
 /// Runs `rglob` against each pathname in `pathnames` and accumulates the results
-std::vector<std::filesystem::path> rglob(const std::vector<std::string> &pathnames);
+std::vector<fs::path> rglob(const std::vector<std::string> &pathnames);
 
 /// Initializer list overload for convenience
-std::vector<std::filesystem::path> glob(const std::initializer_list<std::string> &pathnames);
+std::vector<fs::path> glob(const std::initializer_list<std::string> &pathnames);
 
 /// Initializer list overload for convenience
-std::vector<std::filesystem::path> rglob(const std::initializer_list<std::string> &pathnames);
+std::vector<fs::path> rglob(const std::initializer_list<std::string> &pathnames);
 
 /// Returns true if the input path matche the glob pattern
-  bool fnmatch(const std::filesystem::path &name, const std::string &pattern);
+  bool fnmatch(const fs::path &name, const std::string &pattern);
 
 } // namespace glob

--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -8,9 +8,10 @@
 #include <regex>
 #include <string>
 #include <vector>
-namespace fs = std::filesystem;
 
 namespace glob {
+
+namespace fs = std::filesystem;
 
 namespace {
 
@@ -374,8 +375,8 @@ std::vector<fs::path> rglob(const std::string &pathname) {
 }
 
 static inline 
-std::vector<std::filesystem::path> glob(const std::vector<std::string> &pathnames) {
-  std::vector<std::filesystem::path> result;
+std::vector<fs::path> glob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
   for (auto &pathname : pathnames) {
     for (auto &match : glob(pathname, false)) {
       result.push_back(std::move(match));
@@ -385,8 +386,8 @@ std::vector<std::filesystem::path> glob(const std::vector<std::string> &pathname
 }
 
 static inline 
-std::vector<std::filesystem::path> rglob(const std::vector<std::string> &pathnames) {
-  std::vector<std::filesystem::path> result;
+std::vector<fs::path> rglob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
   for (auto &pathname : pathnames) {
     for (auto &match : glob(pathname, true)) {
       result.push_back(std::move(match));
@@ -396,13 +397,13 @@ std::vector<std::filesystem::path> rglob(const std::vector<std::string> &pathnam
 }
 
 static inline 
-std::vector<std::filesystem::path>
+std::vector<fs::path>
 glob(const std::initializer_list<std::string> &pathnames) {
   return glob(std::vector<std::string>(pathnames));
 }
 
 static inline 
-std::vector<std::filesystem::path>
+std::vector<fs::path>
 rglob(const std::initializer_list<std::string> &pathnames) {
   return rglob(std::vector<std::string>(pathnames));
 }

--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -1,7 +1,6 @@
 
 #pragma once
 #include <cassert>
-#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -9,9 +8,19 @@
 #include <string>
 #include <vector>
 
+#ifdef GLOB_USE_GHC_FILESYSTEM
+#include <ghc/filesystem.hpp>
+#else
+#include <filesystem>
+#endif
+
 namespace glob {
 
+#ifdef GLOB_USE_GHC_FILESYSTEM
+namespace fs = ghc::filesystem;
+#else
 namespace fs = std::filesystem;
+#endif
 
 namespace {
 

--- a/source/glob.cpp
+++ b/source/glob.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <map>
 #include <regex>
-namespace fs = std::filesystem;
 
 namespace glob {
 
@@ -348,8 +347,8 @@ std::vector<fs::path> rglob(const std::string &pathname) {
   return glob(pathname, true);
 }
 
-std::vector<std::filesystem::path> glob(const std::vector<std::string> &pathnames) {
-  std::vector<std::filesystem::path> result;
+std::vector<fs::path> glob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
   for (auto &pathname : pathnames) {
     for (auto &match : glob(pathname, false)) {
       result.push_back(std::move(match));
@@ -358,8 +357,8 @@ std::vector<std::filesystem::path> glob(const std::vector<std::string> &pathname
   return result;
 }
 
-std::vector<std::filesystem::path> rglob(const std::vector<std::string> &pathnames) {
-  std::vector<std::filesystem::path> result;
+std::vector<fs::path> rglob(const std::vector<std::string> &pathnames) {
+  std::vector<fs::path> result;
   for (auto &pathname : pathnames) {
     for (auto &match : glob(pathname, true)) {
       result.push_back(std::move(match));
@@ -368,12 +367,12 @@ std::vector<std::filesystem::path> rglob(const std::vector<std::string> &pathnam
   return result;
 }
 
-std::vector<std::filesystem::path>
+std::vector<fs::path>
 glob(const std::initializer_list<std::string> &pathnames) {
   return glob(std::vector<std::string>(pathnames));
 }
 
-std::vector<std::filesystem::path>
+std::vector<fs::path>
 rglob(const std::initializer_list<std::string> &pathnames) {
   return rglob(std::vector<std::string>(pathnames));
 }


### PR DESCRIPTION
The `README` says:

> If you can't use C++17, you can integrate [gulrak/filesystem](https://github.com/gulrak/filesystem) with minimal effort.

This adds a CMake option to support that without making any code changes.