### PR TITLE
Use platform environment variable instead of platform function

### DIFF
--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -164,13 +164,13 @@ std::vector<fs::path> filter(const std::vector<fs::path> &names,
 static inline 
 fs::path expand_tilde(fs::path path) {
   if (path.empty()) return path;
+
 #ifdef _WIN32
-  char* home;
-  size_t sz;
-  _dupenv_s(&home, &sz, "USERPROFILE");
+  const char * home_variable = "USERNAME";
 #else
-  const char * home = std::getenv("HOME");
+  const char * home_variable = "USER";
 #endif
+  const char * home = std::getenv(home_variable);
   if (home == nullptr) {
     throw std::invalid_argument("error: Unable to expand `~` - HOME environment variable not set.");
   }

--- a/source/glob.cpp
+++ b/source/glob.cpp
@@ -145,7 +145,13 @@ std::vector<fs::path> filter(const std::vector<fs::path> &names,
 fs::path expand_tilde(fs::path path) {
   if (path.empty()) return path;
 
-  const char * home = std::getenv("HOME");
+#ifdef _WIN32
+    const char * home_variable = "USERNAME";
+#else
+    const char * home_variable = "USER";
+#endif
+    const char * home = std::getenv(home_variable);
+
   if (home == nullptr) {
     throw std::invalid_argument("error: Unable to expand `~` - HOME environment variable not set.");
   }


### PR DESCRIPTION
Using a platform dependent function is not a clean solution to getting the username environment variable value. This PR checks the platform and uses different username environment variable names accordingly, and uses the std::getenv function regardless the target platform.