### PR TITLE
optimize and cleanup

### DIFF
--- a/include/glob/glob.h
+++ b/include/glob/glob.h
@@ -45,7 +45,4 @@ std::vector<fs::path> glob(const std::initializer_list<std::string> &pathnames);
 /// Initializer list overload for convenience
 std::vector<fs::path> rglob(const std::initializer_list<std::string> &pathnames);
 
-/// Returns true if the input path matche the glob pattern
-  bool fnmatch(const fs::path &name, const std::string &pattern);
-
 } // namespace glob


### PR DESCRIPTION
- use algorithms instead of 'raw loops'
- use std::string_view instead of std::string in some places
- don't initialize std::regex multiple times in the loop
- use move iterators
- remove fnmatch from header
- remove unused headers
- move our glob header to the top
- separate C lib header from C++ headers

improvements 2.80-4.93x

some benches

Ryzen 5 1600
original:
```
❯ hyperfine -r 412 -N --warmup 10 './build/standalone/glob -i /home/vl/Downloads/**/*.cpp'
Benchmark 1: ./build/standalone/glob -i /home/vl/Downloads/**/*.cpp
  Time (mean ± σ):      51.3 ms ±  10.4 ms    [User: 47.3 ms, System: 3.3 ms]
  Range (min … max):    37.2 ms …  75.5 ms    412 runs
```

optimized version:
```
❯ hyperfine -r 412 -N --warmup 10 './build/standalone/glob -i /home/vl/Downloads/**/*.cpp'
Benchmark 1: ./build/standalone/glob -i /home/vl/Downloads/**/*.cpp
  Time (mean ± σ):      10.4 ms ±   3.9 ms    [User: 6.4 ms, System: 3.6 ms]
  Range (min … max):     6.3 ms …  17.7 ms    412 run
```

Ryzen 9 7950X3D

original version recursive on a lot of files:
peak ram usage 391M
```
❯ hyperfine -N './glob -r -i /var/lib/temppath/**/*.tar.zst'
Benchmark 1: ./glob -r -i /var/lib/temppath/**/*.tar.zst
  Time (mean ± σ):     16.163 s ±  1.225 s    [User: 13.867 s, System: 2.273 s]
  Range (min … max):   15.344 s … 18.979 s    10 runs
```

optimized version recursive on a lot of files:
peak ram usage 261M
```
❯ hyperfine -N './glob -r -i /var/lib/temppath/**/*.tar.zst'
Benchmark 1: ./glob -r -i /var/lib/temppath/**/*.tar.zst
  Time (mean ± σ):      5.757 s ±  0.602 s    [User: 3.469 s, System: 2.278 s]
  Range (min … max):    4.519 s …  6.659 s    10 runs
```