### PR TITLE
Fix for matching with non-existent directories when using patterns like `foo/**`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+cmake-build-debug/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 # ---- Project ----
-
 # Note: update this to your new project's name and version
 project(
-  Glob
-  VERSION 1.0
-  LANGUAGES CXX
+        Glob
+        VERSION 1.0
+        LANGUAGES CXX
 )
 
 # ---- Options ----
@@ -14,12 +13,12 @@ option(GLOB_USE_GHC_FILESYSTEM "Use ghc::filesystem instead of std::filesystem" 
 
 # ---- Include guards ----
 
-if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
-  message(
-    FATAL_ERROR
-      "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there."
-  )
-endif()
+if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+    message(
+            FATAL_ERROR
+            "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there."
+    )
+endif ()
 
 # ---- Add dependencies via CPM ----
 # see https://github.com/TheLartians/CPM.cmake for more info
@@ -28,10 +27,20 @@ include(cmake/CPM.cmake)
 
 # PackageProject.cmake will be used to make our target installable
 CPMAddPackage(
-  NAME PackageProject.cmake
-  GITHUB_REPOSITORY TheLartians/PackageProject.cmake
-  VERSION 1.3
+        NAME PackageProject.cmake
+        GITHUB_REPOSITORY TheLartians/PackageProject.cmake
+        VERSION 1.3
 )
+
+CPMAddPackage(
+        NAME googletest
+        GITHUB_REPOSITORY google/googletest
+        GIT_TAG v1.16.0
+        VERSION 1.16.0
+        OPTIONS "INSTALL_GTEST OFF" "gtest_force_shared_crt"
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # ---- Add source files ----
 
@@ -47,14 +56,14 @@ file(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/
 # INTERFACE_COMPILE_FEATURES cxx_std_17)
 
 add_library(Glob ${headers} ${sources})
-SET_TARGET_PROPERTIES(Glob PROPERTIES OUTPUT_NAME glob)
+set_target_properties(Glob PROPERTIES OUTPUT_NAME glob)
 set_target_properties(Glob PROPERTIES CXX_STANDARD 17)
 
-if ( GLOB_USE_GHC_FILESYSTEM )
-  # Switch to ghc::filesystem.
-  target_link_libraries(Glob PRIVATE ghcFilesystem::ghc_filesystem)
-  target_compile_definitions(Glob PUBLIC GLOB_USE_GHC_FILESYSTEM)
-endif()
+if (GLOB_USE_GHC_FILESYSTEM)
+    # Switch to ghc::filesystem.
+    target_link_libraries(Glob PRIVATE ghcFilesystem::ghc_filesystem)
+    target_compile_definitions(Glob PUBLIC GLOB_USE_GHC_FILESYSTEM)
+endif ()
 
 # being a cross-platform target, we enforce standards conformance on MSVC
 target_compile_options(Glob PUBLIC "$<$<BOOL:${MSVC}>:/permissive->")
@@ -62,8 +71,8 @@ target_compile_options(Glob PUBLIC "$<$<BOOL:${MSVC}>:/permissive->")
 # Link dependencies (if required) target_link_libraries(Glob PUBLIC cxxopts)
 
 target_include_directories(
-  Glob PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                 $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+        Glob PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
 )
 
 # ---- Create an installable target ----
@@ -74,11 +83,26 @@ target_include_directories(
 string(TOLOWER ${PROJECT_NAME}/version.h VERSION_HEADER_LOCATION)
 
 packageProject(
-  NAME ${PROJECT_NAME}
-  VERSION ${PROJECT_VERSION}
-  BINARY_DIR ${PROJECT_BINARY_DIR}
-  INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
-  INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
-  VERSION_HEADER "${VERSION_HEADER_LOCATION}"
-  DEPENDENCIES ""
+        NAME ${PROJECT_NAME}
+        VERSION ${PROJECT_VERSION}
+        BINARY_DIR ${PROJECT_BINARY_DIR}
+        INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
+        INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
+        VERSION_HEADER "${VERSION_HEADER_LOCATION}"
+        DEPENDENCIES ""
 )
+
+# --- setup tests ---
+enable_testing()
+
+add_executable(glob_tests test/rglob_test.cpp)
+set_property(TARGET glob_tests PROPERTY CXX_STANDARD 17)
+target_link_libraries(glob_tests PRIVATE gtest_main ${PROJECT_NAME})
+add_test(NAME glob_tests COMMAND glob_tests)
+
+add_executable(glob_tests_single test/rglob_test.cpp)
+set_property(TARGET glob_tests_single PROPERTY CXX_STANDARD 17)
+target_compile_definitions(glob_tests_single PRIVATE USE_SINGLE_HEADER=1)
+target_link_libraries(glob_tests_single PRIVATE gtest_main)
+target_include_directories(glob_tests_single PRIVATE single_include)
+add_test(NAME glob_tests_single COMMAND glob_tests_single)

--- a/single_include/glob/glob.hpp
+++ b/single_include/glob/glob.hpp
@@ -252,6 +252,10 @@ std::vector<fs::path> glob2(const fs::path &dirname, [[maybe_unused]] const std:
                             bool dironly) {
   // std::cout << "In glob2\n";
   std::vector<fs::path> result;
+  // look into the base directory as well, but only if it exists
+  if (fs::exists(dirname)) {
+    result.push_back(".");
+  }
   assert(is_recursive(pattern));
   for (auto &dir : rlistdir(dirname, dironly)) {
     result.push_back(dir);
@@ -364,7 +368,7 @@ std::vector<fs::path> glob(const std::string &pathname, bool recursive = false,
       if (name.parent_path().empty()) {
         subresult = d / name;
       }
-      result.push_back(subresult);
+      result.push_back(subresult.lexically_normal());
     }
   }
 

--- a/source/glob.cpp
+++ b/source/glob.cpp
@@ -223,7 +223,11 @@ std::vector<fs::path> rlistdir(const fs::path &dirname, bool dironly) {
 std::vector<fs::path> glob2(const fs::path &dirname, [[maybe_unused]] const fs::path &pattern,
                             bool dironly) {
   // std::cout << "In glob2\n";
-  std::vector<fs::path> result{"."};
+  std::vector<fs::path> result;
+  // look into the base directory as well, but only if it exists
+  if (fs::exists(dirname)) {
+    result.push_back(".");
+  }
   assert(is_recursive(pattern.string()));
   auto matched_dirs = rlistdir(dirname, dironly);
   std::copy(std::make_move_iterator(matched_dirs.begin()), std::make_move_iterator(matched_dirs.end()), std::back_inserter(result));

--- a/test/rglob_test.cpp
+++ b/test/rglob_test.cpp
@@ -1,5 +1,7 @@
+#include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
-
+#include <stdlib.h>
 
 #ifdef USE_SINGLE_HEADER
 #include "glob/glob.hpp"
@@ -7,8 +9,42 @@
 #include "glob/glob.h"
 #endif
 
+namespace fs = std::filesystem;
 
+fs::path mkdir_temp() {
+  std::srand(std::time(nullptr));
+  fs::path temp_dir = fs::temp_directory_path() / ("rglob_test_" + std::to_string(std::rand()));
+
+  fs::create_directories(temp_dir);
+  return temp_dir;
+}
+
+// regression test to avoid matching an non existing file
 TEST(rglobTest, MatchNonExistent) {
-    auto matches = glob::rglob("non-existent/**");
-    EXPECT_EQ(matches.size(), 0);
+  auto matches = glob::rglob("non-existent/**");
+  EXPECT_EQ(matches.size(), 0);
+}
+
+// see https://github.com/p-ranav/glob/issues/3
+TEST(rglobTest, Issue3) {
+  auto temp_dir = mkdir_temp();
+  std::cout << "Temporary directory: " << temp_dir << std::endl;
+
+  fs::path sub1 = temp_dir / "sub";
+  fs::path sub2 = sub1 / "sub";
+  EXPECT_TRUE(fs::create_directory(sub1));
+  EXPECT_TRUE(fs::create_directory(sub2));
+
+  std::ofstream(temp_dir / "file.txt").close();
+  std::ofstream(sub1 / "file.txt").close();
+  std::ofstream(sub2 / "file.txt").close();
+
+  auto pattern = temp_dir.string() + "/**/*.txt";
+  std::cout << "Pattern: " << pattern << std::endl;
+
+  auto matches = glob::rglob(pattern);
+  EXPECT_EQ(matches.size(), 3);
+  EXPECT_EQ(matches[0].string(), (temp_dir / "file.txt").string());
+  EXPECT_EQ(matches[1].string(), (sub1 / "file.txt").string());
+  EXPECT_EQ(matches[2].string(), (sub2 / "file.txt").string());
 }

--- a/test/rglob_test.cpp
+++ b/test/rglob_test.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+
+#ifdef USE_SINGLE_HEADER
+#include "glob/glob.hpp"
+#else
+#include "glob/glob.h"
+#endif
+
+
+TEST(rglobTest, MatchNonExistent) {
+    auto matches = glob::rglob("non-existent/**");
+    EXPECT_EQ(matches.size(), 0);
+}


### PR DESCRIPTION
Currently using glob with a pattern like `foo/**` with `foo` not being an actual directory, will return a match `foo/`.
This behavior was introduced with https://github.com/p-ranav/glob/pull/5 
This PR will add tests for both cases as well as a fix