### PR TITLE
Fix `MSVC C4996` warning when using `std::getenv`

### DIFF
--- a/source/glob.cpp
+++ b/source/glob.cpp
@@ -143,6 +143,26 @@ std::vector<fs::path> filter(const std::vector<fs::path> &names,
   return result;
 }
 
+#ifdef _WIN32
+#include <cstdlib>
+
+inline std::string get_env(const char* var) {
+    char* buffer = nullptr;
+    size_t size = 0;
+    if (_dupenv_s(&buffer, &size, var) == 0 && buffer != nullptr) {
+        std::string result(buffer);
+        free(buffer);
+        return result;
+    }
+    return {};
+}
+#else
+inline std::string get_env(const char* var) {
+    const char* value = std::getenv(var);
+    return value ? std::string(value) : "";
+}
+#endif
+
 fs::path expand_tilde(fs::path path) {
   if (path.empty()) return path;
 
@@ -151,10 +171,10 @@ fs::path expand_tilde(fs::path path) {
 #else
     const char * home_variable = "USER";
 #endif
-    const char * home = std::getenv(home_variable);
-
-  if (home == nullptr) {
-    throw std::invalid_argument("error: Unable to expand `~` - HOME environment variable not set.");
+  std::string home = get_env(home_variable);
+  
+  if (home.empty()) {
+      throw std::invalid_argument("error: Unable to expand `~` - HOME environment variable not set.");
   }
 
   std::string s = path.string();


### PR DESCRIPTION
Warning is as follows:

```
warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```

Fix is to create a general `get_env` function that has platform specific code. Alternative solution would be:

```
#if defined(_MSC_VER)
#pragma warning(push)
#pragma warning(disable : 4996) // Disable getenv() deprecation warning
#endif

const char* home = std::getenv(home_variable);

#if defined(_MSC_VER)
#pragma warning(pop)
#endif
```